### PR TITLE
Support Multiple OBSERVATIONS for ORU^R01 in V2.51

### DIFF
--- a/NHapi20/NHapi.Model.V251/Group/ORU_R01_ORDER_OBSERVATION.cs
+++ b/NHapi20/NHapi.Model.V251/Group/ORU_R01_ORDER_OBSERVATION.cs
@@ -151,21 +151,57 @@ get{
 	}
 	}
 
-	///<summary>
-	/// Returns ORU_R01_OBSERVATION (a Group object) - creates it if necessary
-	///</summary>
-	public ORU_R01_OBSERVATION OBSERVATION { 
-get{
-	   ORU_R01_OBSERVATION ret = null;
-	   try {
-	      ret = (ORU_R01_OBSERVATION)this.GetStructure("OBSERVATION");
-	   } catch(HL7Exception e) {
-	      HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected error accessing data - this is probably a bug in the source code generator.", e);
-	      throw new System.Exception("An unexpected error ocurred",e);
-	   }
-	   return ret;
-	}
-	}
+    ///<summary>
+    /// Returns  first repetition of ORU_R01_OBSERVATION (a Group object) - creates it if necessary
+    ///</summary>
+    public ORU_R01_OBSERVATION GetOBSERVATION()
+    {
+        ORU_R01_OBSERVATION ret = null;
+        try
+        {
+            ret = (ORU_R01_OBSERVATION)this.GetStructure("OBSERVATION");
+        }
+        catch (HL7Exception e)
+        {
+            HapiLogFactory.GetHapiLog(GetType()).Error("Unexpected error accessing data - this is probably a bug in the source code generator.", e);
+            throw new System.Exception("An unexpected error ocurred", e);
+        }
+        return ret;
+    }
+
+    ///<summary>
+    ///Returns a specific repetition of ORU_R01_OBSERVATION
+    /// * (a Group object) - creates it if necessary
+    /// throws HL7Exception if the repetition requested is more than one 
+    ///     greater than the number of existing repetitions.
+    ///</summary>
+    public ORU_R01_OBSERVATION GetOBSERVATION(int rep)
+    {
+        return (ORU_R01_OBSERVATION)this.GetStructure("OBSERVATION", rep);
+    }
+
+    /** 
+     * Returns the number of existing repetitions of ORU_R01_OBSERVATION 
+     */
+    public int OBSERVATIONRepetitionsUsed
+    {
+        get
+        {
+            int reps = -1;
+            try
+            {
+                reps = this.GetAll("OBSERVATION").Length;
+            }
+            catch (HL7Exception e)
+            {
+                string message = "Unexpected error accessing data - this is probably a bug in the source code generator.";
+                HapiLogFactory.GetHapiLog(GetType()).Error(message, e);
+                throw new System.Exception(message);
+            }
+            return reps;
+        }
+    } 
+
 
 	///<summary>
 	/// Returns  first repetition of FT1 (Financial Transaction) - creates it if necessary

--- a/NHapi20/NHapi.Model.V251/Group/ORU_R01_ORDER_OBSERVATION.cs
+++ b/NHapi20/NHapi.Model.V251/Group/ORU_R01_ORDER_OBSERVATION.cs
@@ -37,7 +37,7 @@ public class ORU_R01_ORDER_OBSERVATION : AbstractGroup {
 	      this.add(typeof(NTE), false, true);
 	      this.add(typeof(ORU_R01_TIMING_QTY), true, false);
 	      this.add(typeof(CTD), false, false);
-	      this.add(typeof(ORU_R01_OBSERVATION), true, false);
+          this.add(typeof(ORU_R01_OBSERVATION), false, true);
 	      this.add(typeof(FT1), false, true);
 	      this.add(typeof(CTI), false, true);
 	      this.add(typeof(ORU_R01_SPECIMEN), true, false);


### PR DESCRIPTION
Added necessary methods and properties to handle multiple OBSERVATIONS
in the ORU_R01_ORDER_OBSERVATION class for V2.51. Bring in line with
HAPI V2.51 model. Address issue #6.