### PR TITLE
RemoveRepetition

### DIFF
--- a/NHapi20/NHapi.Base/Model/AbstractGroup.cs
+++ b/NHapi20/NHapi.Base/Model/AbstractGroup.cs
@@ -355,12 +355,16 @@ namespace NHapi.Base.Model
 	            throw new HL7Exception("The structure " + name + " does not exist in the group " + GetType().FullName,
 	                HL7Exception.APPLICATION_INTERNAL_ERROR);
 	        }
-
+            if (item.Structures.Count == 0)
+            {
+                throw new HL7Exception(
+                    "Invalid index: " + rep + ", structure " + name + " has no repetitions. ",
+                    HL7Exception.APPLICATION_INTERNAL_ERROR);
+            }
             if (rep >= item.Structures.Count)
             {
-                // return existng Structure if it exists 
                 throw new HL7Exception(
-                    "The structure " + name + " does not have " + rep + " repetitions. ",
+                    "Invalid index: " + rep + ", structure " + name + " must be between 0 and " + (item.Structures.Count - 1),
                     HL7Exception.APPLICATION_INTERNAL_ERROR);
             }
 

--- a/NHapi20/NHapi.Base/Model/AbstractGroup.cs
+++ b/NHapi20/NHapi.Base/Model/AbstractGroup.cs
@@ -347,6 +347,29 @@ namespace NHapi.Base.Model
 			return item.IsRepeating;
 		}
 
+        public virtual IStructure RemoveRepetition(String name, int rep)
+	    {
+            AbstractGroupItem item = GetGroupItem(name);
+	        if (item == null)
+	        {
+	            throw new HL7Exception("The structure " + name + " does not exist in the group " + GetType().FullName,
+	                HL7Exception.APPLICATION_INTERNAL_ERROR);
+	        }
+
+            if (rep >= item.Structures.Count)
+            {
+                // return existng Structure if it exists 
+                throw new HL7Exception(
+                    "The structure " + name + " does not have " + rep + " repetitions. ",
+                    HL7Exception.APPLICATION_INTERNAL_ERROR);
+            }
+
+            IStructure removed = item.Structures[rep];
+            item.Structures.RemoveAt(rep);
+            
+            return removed;
+	    }   
+            
 		/// <summary> Returns the number of existing repetitions of the named structure.</summary>
 		public virtual int currentReps(String name)
 		{

--- a/NHapi20/SharedAssemblyInfo.cs
+++ b/NHapi20/SharedAssemblyInfo.cs
@@ -27,4 +27,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 
 [assembly: AssemblyVersion("2.4.0.11")]
-[assembly: AssemblyFileVersion("2.4.0.11")]
+[assembly: AssemblyInformationalVersion("2.4.0.11-c94379a")]


### PR DESCRIPTION
Our team had need to be able to remove repetitions from a group. This functionality exists in the java HAPI, but had not yet been ported to the C# NHAPI. So I added it, based on inspection of the java implementation.